### PR TITLE
feat: 添加Dependabot自动依赖更新配置

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  # Maven dependencies
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 10
+    target-branch: "main"
+    reviewers:
+      - "SZJM-GWMS/sdk-maintainers"
+    assignees:
+      - "SZJM-GWMS/sdk-maintainers"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "java"
+    ignore:
+      # 忽略主要版本更新，只允许次要和补丁版本
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    target-branch: "main"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## 概述

添加Dependabot配置以自动管理项目依赖更新。

## 变更内容

- ✅ 配置Maven依赖每周自动检查更新
- ✅ 配置GitHub Actions依赖每周自动检查更新  
- ✅ 忽略主要版本更新以确保稳定性
- ✅ 添加自动标签和审查者分配
- ✅ 设置中国时区的执行时间

## 安全考虑

- 仅允许次要版本和补丁版本的自动更新
- 主要版本更新需要手动审查
- 限制同时打开的PR数量

## 测试

- [x] Dependabot配置文件语法正确
- [x] 分支保护规则正常工作
- [x] PR创建流程验证

🤖 此PR将启用自动依赖管理，提升项目安全性。